### PR TITLE
Pi to ESP32 Communication

### DIFF
--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -126,7 +126,7 @@ class Servo(DataSink):
 
         self.limits = []
         self.encoder_maxs = []
-        for i, joint in self.offsets:
+        for i, joint in enumerate(self.offsets):
             limit = [0, 0]
             for subjoint in joint:
                 limit_vals = get_user_config_var(subjoint.name + "_LIMITS", (0, 100))

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -226,13 +226,11 @@ class Servo(DataSink):
             esp_angles[i] = max(self.limits[i][0], min(self.limits[i][1], esp_angles[i]))
         
             # Convert to encoder clicks
+            percent_rotated = (esp_angles[i] - self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
             if i < 5:
-                percent_rotated = (esp_angles[i] - self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
                 esp_angles[i] =  percent_rotated * self.encoder_maxs[i]
             else: # Wrist rotation
                 # We assume that the rotation spans from -max to max instead of 0 to max like the other joints
-                # Add min because it is negative
-                percent_rotated = (esp_angles[i] + self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
                 esp_angles[i] = (2*percent_rotated - 1)*self.encoder_maxs[i]
 
         esp1 = esp_angles[:5]

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -252,7 +252,7 @@ class Servo(DataSink):
         logging.debug('ESP1 JointCmd: ' + msg1)  # 60 us
         logging.debug('ESP2 JointCmd: ' + msg2)
         self.pi.serial_write(self.serial, "<%s>\n" % msg1)
-        self.pi.serial_write(self.serial2, "<%d>\n" % msg2)
+        self.pi.serial_write(self.serial2, "<%s>\n" % msg2)
         
         # Old code I'm putting back to unbreak mpl
         packer = struct.Struct('27f')

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -215,7 +215,7 @@ class Servo(DataSink):
         for i, joint in enumerate(self.offsets):
             for subjoint in joint:
                 esp_angles[i] += degs[subjoint.value]
-            esp_angles[i] = max(self.limits[i][0], min(self.limits[i][1], esp_angles[i]))
+            esp_angles[i] = int(max(self.limits[i][0], min(self.limits[i][1], esp_angles[i])))
         
         esp1 = esp_angles[:5]
         esp2 = esp_angles[5:] #TODO: Use me

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -203,10 +203,10 @@ class Servo(DataSink):
         # Index, middle, ring, and pinky to ESP1
         # For the fingers, we sum the angles of each of the joints of the finger
         esp1_angles = [0]*4
-        logging.debug('Index finger: %d,%d,%d' % (degs[8], degs[9], degs[10]))
+        #logging.debug('Index finger: %d,%d,%d' % (degs[8], degs[9], degs[10]))
         for i, offset in enumerate(self.finger_offsets):
             
-            esp1_angles[i] = sum(degs[i:i+3])
+            esp1_angles[i] = sum(degs[offset:offset+3])
         
         # Thumb and wrist to ESP2
         # TODO

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -246,7 +246,7 @@ class Servo(DataSink):
             esp2[1] += wrist_rot
         
         esp2[0] = max(wrist_fe, esp2[0])
-        esp2[1] += max(wrist_fe, esp2[1])
+        esp2[1] = max(wrist_fe, esp2[1])
         esp2[2] = thumb_ab_ad
 
         # Send data

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -203,12 +203,13 @@ class Servo(DataSink):
         # Index, middle, ring, and pinky to ESP1
         # For the fingers, we sum the angles of each of the joints of the finger
         esp1_angles = [0]*4
+        logging.debug('Index finger: %d,%d,%d' % (degs[8], degs[9], degs[10]))
         for i, offset in enumerate(self.finger_offsets):
-            esp1_angles[i] = sum(degs[i:i+2])
+            
+            esp1_angles[i] = sum(degs[i:i+3])
         
         # Thumb and wrist to ESP2
         # TODO
-        
         
         deg_values = [int(values[joint]*rad_to_deg) for joint in self.servo_joints]
 

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -204,7 +204,7 @@ class Servo(DataSink):
         msg = ','.join(map(str, deg_values))
         logging.debug('JointCmd: ' + msg)  # 60 us
         # self.pi.serial_write(self.serial, "<%s>\n" % msg)
-        self.pi.serial_write(self.serial, "<%d>\n", % deg_values[2]) # index finger
+        self.pi.serial_write(self.serial, "<%d>\n" % deg_values[2]) # index finger
         
         # Old code I'm putting back to unbreak mpl
         packer = struct.Struct('27f')

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -127,7 +127,9 @@ class Servo(DataSink):
         for joint in self.offsets:
             limit = (0.0, 0.0)
             for subjoint in joint:
-                limit += get_user_config_var(subjoint.name + "_LIMITS", (0.0, 100.0))
+                limit_vals = get_user_config_var(subjoint.name + "_LIMITS", (0.0, 100.0))
+                limit[0] += limit_vals[0]
+                limit[1] += limit_vals[1]
             self.limits.append(limit)
         logging.info("Joint limits: " + str(self.limits))
         #self.servo_joint_limits.append(get_user_config_var(MplId(joint).name+'_LIMITS', (0.0, 100.0)))

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -135,7 +135,7 @@ class Servo(DataSink):
             self.limits.append(limit)
 
             encoder_max = get_user_config_var("EncoderMax" + str(i), 90)
-            self.encoder_maxs.push(encoder_max)
+            self.encoder_maxs.append(encoder_max)
         logging.info("Joint limits: " + str(self.limits))
         #self.servo_joint_limits.append(get_user_config_var(MplId(joint).name+'_LIMITS', (0.0, 100.0)))
 

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -227,7 +227,7 @@ class Servo(DataSink):
         
             # Convert to encoder clicks
             percent_rotated = (esp_angles[i] - self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
-            if i < 5:
+            if i != 5:
                 esp_angles[i] =  percent_rotated * self.encoder_maxs[i]
             else: # Wrist rotation
                 # We assume that the rotation spans from -max to max instead of 0 to max like the other joints

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -241,7 +241,7 @@ class Servo(DataSink):
         # The ESP expects <rot left, rot right, thumb ab ad>, where flexion is achieved through
         #   setting both rotations to positive.
         esp2 = [0]*3
-        logging.info("Raw esp2 data: " + str(esp2))
+        logging.info("Raw esp2 data: " + str(esp_angles[5:]))
         if(wrist_rot < 0): # Rotate left
             esp2[0] -= wrist_rot
         else: # Rotate right

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -222,10 +222,10 @@ class Servo(DataSink):
                 esp_angles[i] += degs[subjoint.value]
             
             # Bound
-            esp_angles[i] = int(max(self.limits[i][0], min(self.limits[i][1], esp_angles[i])))
+            esp_angles[i] = max(self.limits[i][0], min(self.limits[i][1], esp_angles[i]))
         
             # Convert to encoder clicks
-            percent_rotated = (esp_angles[i] - self.limits[i][0]) // (self.limits[i][1] - self.limits[i][0])
+            percent_rotated = (esp_angles[i] - self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
             if i < 5:
                 esp_angles[i] =  percent_rotated * self.encoder_maxs[i]
             else: # Wrist rotation
@@ -247,8 +247,9 @@ class Servo(DataSink):
         esp2[2] = thumb_ab_ad
 
         # Send data
-        msg1 = ','.join(map(str, esp1))
-        msg2 = ",".join(map(str, esp2))
+        fmnt = lambda angle: str(int(angle))
+        msg1 = ','.join(map(fmnt, esp1))
+        msg2 = ",".join(map(fmnt, esp2))
         logging.debug('ESP1 JointCmd: ' + msg1)  # 60 us
         logging.debug('ESP2 JointCmd: ' + msg2)
         self.pi.serial_write(self.serial, "<%s>\n" % msg1)

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -125,7 +125,7 @@ class Servo(DataSink):
 
         self.limits = []
         for joint in self.offsets:
-            limit = (0.0, 0.0)
+            limit = [0.0, 0.0]
             for subjoint in joint:
                 limit_vals = get_user_config_var(subjoint.name + "_LIMITS", (0.0, 100.0))
                 limit[0] += limit_vals[0]

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -125,9 +125,9 @@ class Servo(DataSink):
 
         self.limits = []
         for joint in self.offsets:
-            limit = [0.0, 0.0]
+            limit = [0, 0]
             for subjoint in joint:
-                limit_vals = get_user_config_var(subjoint.name + "_LIMITS", (0.0, 100.0))
+                limit_vals = get_user_config_var(subjoint.name + "_LIMITS", (0, 100))
                 limit[0] += limit_vals[0]
                 limit[1] += limit_vals[1]
             self.limits.append(limit)

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -134,9 +134,10 @@ class Servo(DataSink):
                 limit[1] += limit_vals[1]
             self.limits.append(limit)
 
-            encoder_max = get_user_config_var("EncoderMax" + str(i), 90)
+            encoder_max = get_user_config_var("Servo.EncoderMax" + str(i), 90)
             self.encoder_maxs.append(encoder_max)
         logging.info("Joint limits: " + str(self.limits))
+        logging.info("Encoder maxs: " + str(self.encoder_maxs))
         #self.servo_joint_limits.append(get_user_config_var(MplId(joint).name+'_LIMITS', (0.0, 100.0)))
 
     def load_config_parameters(self):
@@ -225,11 +226,13 @@ class Servo(DataSink):
             esp_angles[i] = max(self.limits[i][0], min(self.limits[i][1], esp_angles[i]))
         
             # Convert to encoder clicks
-            percent_rotated = (esp_angles[i] - self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
             if i < 5:
+                percent_rotated = (esp_angles[i] - self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
                 esp_angles[i] =  percent_rotated * self.encoder_maxs[i]
             else: # Wrist rotation
                 # We assume that the rotation spans from -max to max instead of 0 to max like the other joints
+                # Add min because it is negative
+                percent_rotated = (esp_angles[i] + self.limits[i][0]) / (self.limits[i][1] - self.limits[i][0])
                 esp_angles[i] = (2*percent_rotated - 1)*self.encoder_maxs[i]
 
         esp1 = esp_angles[:5]

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -244,8 +244,9 @@ class Servo(DataSink):
             esp2[0] -= wrist_rot
         else: # Rotate right
             esp2[1] += wrist_rot
-        esp2[0] += wrist_fe
-        esp2[1] += wrist_fe
+        
+        esp2[0] = max(wrist_fe, esp2[0])
+        esp2[1] += max(wrist_fe, esp2[1])
         esp2[2] = thumb_ab_ad
 
         # Send data

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -241,6 +241,7 @@ class Servo(DataSink):
         # The ESP expects <rot left, rot right, thumb ab ad>, where flexion is achieved through
         #   setting both rotations to positive.
         esp2 = [0]*3
+        logging.info("Raw esp2 data: " + str(esp2))
         if(wrist_rot < 0): # Rotate left
             esp2[0] -= wrist_rot
         else: # Rotate right

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -117,9 +117,9 @@ class Servo(DataSink):
         self.servo_motor_limits = []
         self.servo_joint_limits = []
         for i in range(0, self.servo_num):
-            joint = get_user_config_var('Servo.JointLink'+str(i), 4)
+            joint = get_user_config_var('Servo.JointLink'+str(i+1), 4)
             self.servo_joints.append(joint)
-            self.servo_motor_limits.append(get_user_config_var('Servo.MotorLimit'+str(i), (500, 2500)))
+            self.servo_motor_limits.append(get_user_config_var('Servo.MotorLimit'+str(i+1), (500, 2500)))
             self.servo_joint_limits.append(get_user_config_var(MplId(joint).name+'_LIMITS', (0.0, 100.0)))
 
     def load_config_parameters(self):
@@ -203,7 +203,8 @@ class Servo(DataSink):
         # Send data
         msg = ','.join(map(str, deg_values))
         logging.debug('JointCmd: ' + msg)  # 60 us
-        self.pi.serial_write(self.serial, "<%s>\n" % msg)
+        # self.pi.serial_write(self.serial, "<%s>\n" % msg)
+        self.pi.serial_write(self.serial, "<%d>\n", % deg_values[2]) # index finger
         
         # Old code I'm putting back to unbreak mpl
         packer = struct.Struct('27f')

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -213,7 +213,7 @@ class Servo(DataSink):
         
         esp_angles = [0]*8
         for i, joint in enumerate(self.offsets):
-            for subjiont in joint:
+            for subjoint in joint:
                 esp_angles[i] += degs[subjoint.value]
             esp_angles[i] = max(self.limits[i][0], min(self.limits[i][1], esp_angles[i]))
         

--- a/python/minivie/mpl/servo.py
+++ b/python/minivie/mpl/servo.py
@@ -197,6 +197,7 @@ class Servo(DataSink):
 
         # Apply joint offsets if needed
         values = np.array(values) + self.joint_offset
+        rad_to_deg = 57.2957795  # 180/pi
         degs = [int(angle*rad_to_deg) for angle in values]
         
         # Index, middle, ring, and pinky to ESP1
@@ -208,7 +209,7 @@ class Servo(DataSink):
         # Thumb and wrist to ESP2
         # TODO
         
-        rad_to_deg = 57.2957795  # 180/pi
+        
         deg_values = [int(values[joint]*rad_to_deg) for joint in self.servo_joints]
 
         # Send data

--- a/python/minivie/vmpl_user_config.xml
+++ b/python/minivie/vmpl_user_config.xml
@@ -127,7 +127,7 @@
     <add key="Servo.EncoderMax1"    value="85" /> <!-- Middle -->
     <add key="Servo.EncoderMax2"    value="85" /> <!-- Ring-->
     <add key="Servo.EncoderMax3"    value="85" /> <!-- Little -->
-    <add key="Servo.EncoderMax4"    value="95" /> <!-- Thumb -->
+    <add key="Servo.EncoderMax4"    value="60" /> <!-- Thumb --> <!-- TODO: Brady says this should be 95 -->
 
     <!-- Special exception: the wrist rotation min is expected to be -max -->
     <add key="Servo.EncoderMax5"    value="20" /> <!-- Wrist rotation -->

--- a/python/minivie/vmpl_user_config.xml
+++ b/python/minivie/vmpl_user_config.xml
@@ -123,17 +123,17 @@
 
     <!-- Servo Information -->
     <!-- The minimum is assumed to be 0 -->
-    <add key="Servo.EncoderMax1"    value="85" /> <!-- Index -->
-    <add key="Servo.EncoderMax2"    value="85" /> <!-- Middle -->
-    <add key="Servo.EncoderMax3"    value="85" /> <!-- Ring-->
-    <add key="Servo.EncoderMax4"    value="85" /> <!-- Little -->
-    <add key="Servo.EncoderMax5"    value="95" /> <!-- Thumb -->
+    <add key="Servo.EncoderMax0"    value="85" /> <!-- Index -->
+    <add key="Servo.EncoderMax1"    value="85" /> <!-- Middle -->
+    <add key="Servo.EncoderMax2"    value="85" /> <!-- Ring-->
+    <add key="Servo.EncoderMax3"    value="85" /> <!-- Little -->
+    <add key="Servo.EncoderMax4"    value="95" /> <!-- Thumb -->
 
     <!-- Special exception: the wrist rotation min is expected to be -max -->
-    <add key="Servo.EncoderMax6"    value="20" /> <!-- Wrist rotation -->
+    <add key="Servo.EncoderMax5"    value="20" /> <!-- Wrist rotation -->
 
-    <add key="Servo.EncoderMax7"    value="20" /> <!-- Wrist FE -->
-    <add key="Servo.EncoderMax8"    value="30" /> <!-- Thumb AB AD -->
+    <add key="Servo.EncoderMax6"    value="20" /> <!-- Wrist FE -->
+    <add key="Servo.EncoderMax7"    value="30" /> <!-- Thumb AB AD -->
 
     <!-- User defined joint limits in *Degrees*
      Optionally limit the range of each joint prior to sending to the MPL

--- a/python/minivie/vmpl_user_config.xml
+++ b/python/minivie/vmpl_user_config.xml
@@ -173,7 +173,7 @@
     <add key="THUMB_CMC_AB_AD_LIMITS" value="  0, 52" />
     <add key="THUMB_CMC_FE_LIMITS"    value="   8, 80" />
     <add key="THUMB_MCP_LIMITS"       value="   0, 80" />
-    <add key="THUMB_DIP_LIMITS"       value=" -12, 60" />
+    <add key="THUMB_DIP_LIMITS"       value=" 0, 60" />
 
     <!-- Joint direction parameters to flip joint direction +/- 1 -->    
     <add key="WRIST_FE_DIRECTION"        value="+1" />

--- a/python/minivie/vmpl_user_config.xml
+++ b/python/minivie/vmpl_user_config.xml
@@ -165,28 +165,28 @@
     <add key="WRIST_FE_LIMITS"        value=" -60, 60" />
 
     <add key="INDEX_AB_AD_LIMITS"     value=" -20, 0" />
-    <add key="INDEX_MCP_LIMITS"       value=" -40, 85" />
+    <add key="INDEX_MCP_LIMITS"       value=" 0, 85" />
     <add key="INDEX_PIP_LIMITS"       value="   0, 100" />
     <add key="INDEX_DIP_LIMITS"       value="   0, 80" />
 
     <add key="MIDDLE_AB_AD_LIMITS"    value=" -20, 0" />
-    <add key="MIDDLE_MCP_LIMITS"      value=" -40, 85" />
+    <add key="MIDDLE_MCP_LIMITS"      value=" 0, 85" />
     <add key="MIDDLE_PIP_LIMITS"      value="   0, 100" />
     <add key="MIDDLE_DIP_LIMITS"      value="   0, 80" />
 
     <add key="RING_AB_AD_LIMITS"      value="   0, 20" />
-    <add key="RING_MCP_LIMITS"        value=" -40, 85" />
+    <add key="RING_MCP_LIMITS"        value=" 0, 85" />
     <add key="RING_PIP_LIMITS"        value="   0, 100" />
     <add key="RING_DIP_LIMITS"        value="   0, 80" />
 
     <add key="LITTLE_AB_AD_LIMITS"    value="   0, 20" />
-    <add key="LITTLE_MCP_LIMITS"      value=" -40, 85" />
+    <add key="LITTLE_MCP_LIMITS"      value=" 0, 85" />
     <add key="LITTLE_PIP_LIMITS"      value="   0, 100" />
     <add key="LITTLE_DIP_LIMITS"      value="   0, 80" />
 
     <add key="THUMB_CMC_AB_AD_LIMITS" value="  8, 135" />
     <add key="THUMB_CMC_FE_LIMITS"    value="   8, 80" />
-    <add key="THUMB_MCP_LIMITS"       value="   8, 80" />
+    <add key="THUMB_MCP_LIMITS"       value="   0, 80" />
     <add key="THUMB_DIP_LIMITS"       value=" -12, 60" />
 
     <!-- Joint direction parameters to flip joint direction +/- 1 -->    

--- a/python/minivie/vmpl_user_config.xml
+++ b/python/minivie/vmpl_user_config.xml
@@ -130,9 +130,9 @@
     <add key="Servo.EncoderMax4"    value="60" /> <!-- Thumb --> <!-- TODO: Brady says this should be 95 -->
 
     <!-- Special exception: the wrist rotation min is expected to be -max -->
-    <add key="Servo.EncoderMax5"    value="20" /> <!-- Wrist rotation -->
+    <add key="Servo.EncoderMax5"    value="85" /> <!-- Wrist rotation -->
 
-    <add key="Servo.EncoderMax6"    value="20" /> <!-- Wrist FE -->
+    <add key="Servo.EncoderMax6"    value="85" /> <!-- Wrist FE -->
     <add key="Servo.EncoderMax7"    value="30" /> <!-- Thumb AB AD -->
 
     <!-- User defined joint limits in *Degrees*

--- a/python/minivie/vmpl_user_config.xml
+++ b/python/minivie/vmpl_user_config.xml
@@ -121,33 +121,19 @@
     <add key="MPL.HandSpeedDefault"    value="1.2"/>
     <add key="MPL.HandSpeedPrecision"    value="0.15"/>
 
-    <!-- Servo Motor Information -->
-    <add key="Servo.Num"    value="8"/>
-    <add key="Servo.GPIO1"    value="17"/>
-    <add key="Servo.GPIO2"    value="27"/>
-    <add key="Servo.GPIO3"    value="22"/>
-    <add key="Servo.GPIO4"    value="10"/>
-    <add key="Servo.GPIO5"    value="9"/>
-    <add key="Servo.GPIO6"    value="11"/>
-    <add key="Servo.GPIO7"    value="5"/>
-    <add key="Servo.GPIO8"    value="6"/>
-    <add key="Servo.MotorLimit1"    value=" 700, 1600" />
-    <add key="Servo.MotorLimit2"    value=" 600, 2200" />
-    <add key="Servo.MotorLimit3"    value=" 600, 2200" />
-    <add key="Servo.MotorLimit4"    value=" 600, 2200" />
-    <add key="Servo.MotorLimit5"    value=" 600, 2200" />
-    <add key="Servo.MotorLimit6"    value=" 600, 2200" />
-    <add key="Servo.MotorLimit7"    value=" 600, 2200" />
-    <add key="Servo.MotorLimit8"    value=" 600, 2200" />
-    <!-- TODO: Use mpl.JointEnum to reference joints by name instead -->
-    <add key="Servo.JointLink1"    value="4" /> <!-- Wrist rotation -->
-    <add key="Servo.JointLink2"    value="6" /> <!-- Wrist FE -->
-    <add key="Servo.JointLink3"    value="8" /> <!-- Index MCP -->
-    <add key="Servo.JointLink4"    value="12" /> <!-- Middle MCP -->
-    <add key="Servo.JointLink5"    value="16" /> <!-- Ring MCP-->
-    <add key="Servo.JointLink6"    value="20" /> <!-- Little MCP -->
-    <add key="Servo.JointLink7"    value="25" /> <!-- Thumb MCP -->
-    <add key="Servo.JointLink8"    value="23" /> <!-- Thumb AB AD -->
+    <!-- Servo Information -->
+    <!-- The minimum is assumed to be 0 -->
+    <add key="Servo.EncoderMax1"    value="85" /> <!-- Index -->
+    <add key="Servo.EncoderMax2"    value="85" /> <!-- Middle -->
+    <add key="Servo.EncoderMax3"    value="85" /> <!-- Ring-->
+    <add key="Servo.EncoderMax4"    value="85" /> <!-- Little -->
+    <add key="Servo.EncoderMax5"    value="95" /> <!-- Thumb -->
+
+    <!-- Special exception: the wrist rotation min is expected to be -max -->
+    <add key="Servo.EncoderMax6"    value="20" /> <!-- Wrist rotation -->
+
+    <add key="Servo.EncoderMax7"    value="20" /> <!-- Wrist FE -->
+    <add key="Servo.EncoderMax8"    value="30" /> <!-- Thumb AB AD -->
 
     <!-- User defined joint limits in *Degrees*
      Optionally limit the range of each joint prior to sending to the MPL
@@ -160,9 +146,9 @@
     <add key="HUMERAL_ROT_LIMITS"     value=" -35, 80" />
     <add key="ELBOW_LIMITS"           value="   0, 130" />
 
-    <add key="WRIST_ROT_LIMITS"       value=" -85, 85" />
+    <add key="WRIST_ROT_LIMITS"       value=" -45, 45" />
     <add key="WRIST_AB_AD_LIMITS"     value=" -45, 45" />
-    <add key="WRIST_FE_LIMITS"        value=" -60, 60" />
+    <add key="WRIST_FE_LIMITS"        value=" 0, 45" />
 
     <add key="INDEX_AB_AD_LIMITS"     value=" -20, 0" />
     <add key="INDEX_MCP_LIMITS"       value=" 0, 85" />
@@ -184,7 +170,7 @@
     <add key="LITTLE_PIP_LIMITS"      value="   0, 100" />
     <add key="LITTLE_DIP_LIMITS"      value="   0, 80" />
 
-    <add key="THUMB_CMC_AB_AD_LIMITS" value="  8, 135" />
+    <add key="THUMB_CMC_AB_AD_LIMITS" value="  0, 52" />
     <add key="THUMB_CMC_FE_LIMITS"    value="   8, 80" />
     <add key="THUMB_MCP_LIMITS"       value="   0, 80" />
     <add key="THUMB_DIP_LIMITS"       value=" -12, 60" />

--- a/python/minivie/vmpl_user_config.xml
+++ b/python/minivie/vmpl_user_config.xml
@@ -127,7 +127,7 @@
     <add key="Servo.EncoderMax1"    value="85" /> <!-- Middle -->
     <add key="Servo.EncoderMax2"    value="85" /> <!-- Ring-->
     <add key="Servo.EncoderMax3"    value="85" /> <!-- Little -->
-    <add key="Servo.EncoderMax4"    value="60" /> <!-- Thumb --> <!-- TODO: Brady says this should be 95 -->
+    <add key="Servo.EncoderMax4"    value="85" /> <!-- Thumb -->
 
     <!-- Special exception: the wrist rotation min is expected to be -max -->
     <add key="Servo.EncoderMax5"    value="85" /> <!-- Wrist rotation -->


### PR DESCRIPTION
Now sends target joint positions to both ESP32 over serial ports.
Unit conversion to encoder ticks now done in code as a linear interpolation between joint angle limits and encoder maximums.
Added config for setting encoder maximums and removed config for GPIO pins.